### PR TITLE
Check if zip archive has a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ use Zip;
 
     ```
 
+
+- Check if zip has a file:
+
+    ```php    
+    // Check if archive has a file
+    $zip->has('/path/to/file/in/archive');
+
+    // Check if archive has a file case insensitively
+    $zip->has('/path/to/file/in/archive', ZipArchive::FL_NOCASE);
+
+    // Check if archive has a file ignoring directory component
+    $zip->has('file', ZipArchive::FL_NODIR);
+
+    // Check if archive has a file case insensitively ignoring directory component
+    $zip->has('file', ZipArchive::FL_NOCASE|ZipArchive::FL_NODIR);
+
+    ```
+
 - Add a file/directory to zip:
 
     ```php    
@@ -275,3 +293,4 @@ use Zip;
     $mask = $manager->getMask();
 
     ```
+

--- a/src/Zip.php
+++ b/src/Zip.php
@@ -381,7 +381,7 @@ class Zip {
      */
 	public function has($file, $flags = 0) {
 
-        if ( empty($destination) ) throw new Exception('Invalid File');
+        if ( empty($file) ) throw new Exception('Invalid File');
 
         return $this->zip_archive->locateName($file, $flags) !== false;
 

--- a/src/Zip.php
+++ b/src/Zip.php
@@ -371,7 +371,21 @@ class Zip {
         return $list;
 
     }
+    /**
+     * Check if zip archive has a file
+     *
+     * @param   string  $file    File
+     * @param   int     $flags   (optional) ZipArchive::FL_NOCASE, ZipArchive::FL_NODIR seperated by bitwise OR
+     *
+     * @return  bool
+     */
+	public function has($file, $flags = 0) {
 
+        if ( empty($destination) ) throw new Exception('Invalid File');
+
+        return $this->zip_archive->locateName($file, $flags) !== false;
+
+    }
     /**
      * Extract files from zip archive
      *
@@ -648,3 +662,4 @@ class Zip {
     }
 
 }
+


### PR DESCRIPTION
Additional feature for ease of use.
Use case: Call before extract to avoid exceptions (or for validations?):
```php
$zip = Zip::open('/path');
if ($zip->has('file')) {
    $zip->extract('/destination', 'file');
}