### PR TITLE
Mark project as abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "laravel-zip is the world's leading zip utility for file compression and backup.",
     "license": "MIT",
     "homepage": "http://www.zanysoft.co",
+    "abandoned": true,
     "authors": [
         {
             "name": "Zany Soft",


### PR DESCRIPTION
It's good common courtesy to mark a package as abandoned if it's no longer receiving development or updates, which is the case for this project. Leaving it without an abandoned task causes people to spend time installing it, trying to get it to work and then finding out it's not working and the likelihood of even being able to get a PR accepted with fixes is low.