### PR TITLE
Allow installing on Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   ],
   "require": {
     "php": ">=7.4",
-    "illuminate/support": "^7.0|^8.0|^9.0",
+    "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
     "ext-zip": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Laravel 10 was [just released](https://laravel-news.com/laravel-10), and it looks to me like there aren't any breaking changes that cause trouble with this package. It works just fine with Laravel 10 in the app I'm building with it after a `composer install`.

I've never really done much package development before and wasn't able to get `phpunit` to run on the package directly at all (`Class "zanysoft.zip" does not exist`, which appears to be a facade resolution issue) - But I'm fairly certain that's my own inexperience and not something wrong with this package.